### PR TITLE
🎨 Store validated data in scrna example

### DIFF
--- a/docs/datatype/10-scrna.ipynb
+++ b/docs/datatype/10-scrna.ipynb
@@ -168,6 +168,8 @@
     "    .str.replace(\"organism\", \"species\")\n",
     "    .str.replace(\"developmental stage\", \"developmental_stage\")\n",
     "    .str.replace(\"cell type\", \"cell_type\")\n",
+    "    # the last one could be interesting, too\n",
+    "    # .str.replace(\"Factor Value:Ontology Term[inferred cell_type - authors labels\", \"cell_type_authors\")\n",
     ")\n",
     "\n",
     "adata"
@@ -179,6 +181,54 @@
    "metadata": {},
    "source": [
     "When we create a `File` object from an `AnnData`, we'll automatically link its feature sets and get information about unmapped categories:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file = ln.File.from_anndata(\n",
+    "    adata, description=\"Detmar22\", var_ref=lb.Gene.ensembl_gene_id\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We're seeing that several gene identifiers can't be validated through Bionty. We'd like to validate all features in this dataset, hence, let's register them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.save(lb.Gene.from_values(adata.var.index, lb.Gene.ensembl_gene_id))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly, for the metadata, we'd like to validate the names:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "columns = [\n",
+    "    col\n",
+    "    for col in adata.obs.columns\n",
+    "    if not col.startswith(\"ontology_id\") and not col.startswith(\"Factor Value\")\n",
+    "]\n",
+    "ln.save(ln.Feature.from_df(adata.obs[columns]))"
    ]
   },
   {
@@ -221,7 +271,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Some of the metadata can be typed:"
+    "Some of the metadata can be typed using dedicated registries:"
    ]
   },
   {
@@ -242,6 +292,56 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We did not validate strains, hence, let's try to map synonyms:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lb.ExperimentalFactor.map_synonyms(adata.obs[\"strain\"], return_mapper=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Indeed, there is a synonym:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.obs[\"strain\"] = adata.obs[\"strain\"].map(\n",
+    "    lb.ExperimentalFactor.map_synonyms(adata.obs[\"strain\"], return_mapper=True)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can validate:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "strains = lb.ExperimentalFactor.from_values(adata.obs[\"strain\"], \"name\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -255,7 +355,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Metadata that doesn't have corresponding ORMs:"
+    "Metadata that doesn't have can't be typed with dedicated registries:"
    ]
   },
   {
@@ -331,6 +431,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.save(lb.Gene.from_values(conde22.var.index, lb.Gene.ensembl_gene_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conde22.obs.columns = conde22.obs.columns.str.replace(\"donor_id\", \"donor\")\n",
+    "columns = [col for col in conde22.obs.columns if \"ontology_term\" not in col]\n",
+    "ln.save(ln.Feature.from_df(conde22.obs[columns]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": [
      "hide-output"
@@ -340,7 +460,15 @@
    "source": [
     "file = ln.File.from_anndata(\n",
     "    conde22, description=\"Conde22\", var_ref=lb.Gene.ensembl_gene_id\n",
-    ")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "file.save()"
    ]
   },
@@ -409,7 +537,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "donors = ln.Label.from_values(conde22.obs[\"donor_id\"])\n",
+    "donors = ln.Label.from_values(conde22.obs[\"donor\"])\n",
     "file.features.add_labels(donors)"
    ]
   },
@@ -480,17 +608,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "file_pbcm68k = ln.File.from_anndata(\n",
-    "    pbcm68k, description=\"10x reference pbmc68k\", var_ref=lb.Gene.symbol\n",
-    ")\n",
-    "file_pbcm68k.save()"
+    "validated = lb.Gene.inspect(pbcm68k.var.index, lb.Gene.symbol)[\"mapped\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pbcm68k_validated = pbcm68k[:, validated]"
    ]
   },
   {
@@ -511,17 +641,37 @@
    "outputs": [],
    "source": [
     "# inspect shows none of the terms are mappable\n",
-    "lb.CellType.inspect(pbcm68k.obs[\"cell_type\"], \"name\")\n",
+    "lb.CellType.inspect(pbcm68k_validated.obs[\"cell_type\"], \"name\")\n",
     "\n",
     "# here we search the cell type names from the public ontology and grab the top match\n",
     "# then add the cell type names from the pbcm68k as synonyms\n",
     "celltype_bt = lb.CellType.bionty()\n",
     "ontology_ids = []\n",
-    "for ct in pbcm68k.obs[\"cell_type\"].unique():\n",
+    "mapper = {}\n",
+    "for ct in pbcm68k_validated.obs[\"cell_type\"].unique():\n",
     "    ontology_id = celltype_bt.search(ct).iloc[0].ontology_id\n",
     "    record = lb.CellType.from_bionty(ontology_id=ontology_id)\n",
+    "    mapper[ct] = record.name\n",
     "    record.save()\n",
-    "    record.add_synonym(ct)"
+    "    record.add_synonym(ct)\n",
+    "\n",
+    "pbcm68k_validated.obs[\"cell_type\"] = pbcm68k_validated.obs[\"cell_type\"].map(mapper)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, all cell types should be validated:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lb.CellType.inspect(pbcm68k_validated.obs[\"cell_type\"], \"name\")"
    ]
   },
   {
@@ -534,7 +684,31 @@
    },
    "outputs": [],
    "source": [
-    "cell_types = lb.CellType.from_values(pbcm68k.obs[\"cell_type\"], \"name\")\n",
+    "file_pbcm68k = ln.File.from_anndata(\n",
+    "    pbcm68k_validated, description=\"10x reference pbmc68k\", var_ref=lb.Gene.symbol\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_pbcm68k.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "cell_types = lb.CellType.from_values(pbcm68k_validated.obs[\"cell_type\"], \"name\")\n",
     "file_pbcm68k.features.add_labels(cell_types)"
    ]
   },

--- a/docs/datatype/20-scrna-1.ipynb
+++ b/docs/datatype/20-scrna-1.ipynb
@@ -123,6 +123,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file2_adata.obs.cell_type"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -210,50 +219,6 @@
     "    file1_adata.obs[\"cell_type\"].isin(shared_celltypes_names)\n",
     "]\n",
     "file1_adata_subset.obs[\"cell_type\"].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "But when we subset the 2nd file, we don't see the two cell types, why?\n",
-    "\n",
-    "Because they are labeled with synonyms!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "file2_adata_subset = file2_adata[\n",
-    "    file2_adata.obs[\"cell_type\"].isin(shared_celltypes_names)\n",
-    "]\n",
-    "file2_adata_subset.obs[\"cell_type\"].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can easily standardize them using `.map_synonyms`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "file2_adata.obs[\"cell_type\"] = lb.CellType.map_synonyms(file2_adata.obs[\"cell_type\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we have the two cell types:"
    ]
   },
   {


### PR DESCRIPTION
As discussed @sunnyosun, and as we do in most of our production projects already, I think we should always store validated data rather than relying on map_synonyms when retrieving data from the warehouse.

It's better if one curater use map_synonyms to ensure data enters the warehouse validated, rather than all analysts always dealing with the complexity of standardizing data using map_synonyms, isn't it?

- https://github.com/laminlabs/lamindb/pull/993