### PR TITLE
🎨 Adapt sc-imaging2 to anndata 0.12

### DIFF
--- a/docs/sc-imaging2.ipynb
+++ b/docs/sc-imaging2.ipynb
@@ -36,6 +36,16 @@
    },
    "outputs": [],
    "source": [
+    "# Fix anndata>=0.12.0 forward slash restriction\n",
+    "import anndata._io.specs.registry as registry\n",
+    "\n",
+    "original_write = registry.Writer.write_elem\n",
+    "registry.Writer.write_elem = (\n",
+    "    lambda self, store, k, elem, dataset_kwargs=None: original_write(\n",
+    "        self, store, str(k).replace(\"/\", \"|\"), elem, dataset_kwargs=dataset_kwargs\n",
+    "    )\n",
+    ")\n",
+    "\n",
     "import lamindb as ln\n",
     "from collections.abc import Iterable\n",
     "\n",
@@ -326,7 +336,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project.plot_single_cell_images()"
+    "# Fix anndata>=0.12.0 forward slash restriction\n",
+    "# The original code was: project.plot_single_cell_images()\n",
+    "\n",
+    "from scportrait.plotting.h5sc import cell_grid\n",
+    "\n",
+    "adata = project.h5sc\n",
+    "adata.uns[\"single_cell_images\"] = {\n",
+    "    k.split(\"|\")[1]: v\n",
+    "    for k, v in adata.uns.items()\n",
+    "    if k.startswith(\"single_cell_images|\")\n",
+    "}\n",
+    "cell_grid(adata, n_cells=5)"
    ]
   },
   {


### PR DESCRIPTION
Fix forward slash keys compatibility with anndata 0.12.0. This patch replaces '/' with '|' in all keys during write operations using `anndata._io.specs.registry.Writer.write_elem`.

Replaced `project.plot_single_cell_images()` method with a workaround using `scportrait.plotting.h5sc.cell_grid`. 